### PR TITLE
fix: revert "fix: [] do not force squash merging"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         github-token: ${{ steps.vault.outputs.GITHUB_MERGE_TOKEN }}
     - name: Enable auto merge
       shell: bash
-      run: gh pr merge --auto ${{ github.event.pull_request.html_url }}
+      run: gh pr merge -ds --auto ${{ github.event.pull_request.html_url }}
       env:
         GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_MERGE_TOKEN }}
         


### PR DESCRIPTION
You must specify the merge strategy otherwise you get an error:

```
 --merge, --rebase, or --squash required when not running interactively
```

https://contentful.slack.com/archives/CBK9Y263Z/p1667318334082009?thread_ts=1667316560.721049&cid=CBK9Y263Z