### PR TITLE
feat: bump dependencies to use node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Retrieve Github Token
       id: vault
-      uses: hashicorp/vault-action@v2.4.1
+      uses: hashicorp/vault-action@v2.4.3
       with:
         url: ${{ inputs.VAULT_URL }}
         role: ${{ github.event.repository.name }}-github-action
@@ -22,7 +22,7 @@ runs:
         secrets: |
           github/token/${{ github.event.repository.name }}-dependabot token | GITHUB_MERGE_TOKEN ;
     - name: approve PR
-      uses: actions/github-script@v5.0.0
+      uses: actions/github-script@6.3.3
       with:
         script: |
           const opts = github.rest.pulls.listReviews.endpoint.merge({
@@ -55,4 +55,4 @@ runs:
       run: gh pr merge -ds --auto ${{ github.event.pull_request.html_url }}
       env:
         GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_MERGE_TOKEN }}
-        
+


### PR DESCRIPTION
Bumping the action dependencies to the latest and greatest to ensure all action use `node 16`.
Since Github actions have a min required version of node 16, all actions already run on this version. 

as far as I can see we don't bump the action version as long as nothing is breaking - right? 

For Reference:
- https://github.com/hashicorp/vault-action/pull/375
- https://github.com/actions/github-script#breaking-changes