### PR TITLE
fix: don't override GITHUB_TOKEN

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,3 +88,7 @@ runs:
         merge_method="$(echo ${{ steps.merge-type.outputs.result }} | tr -d '"')"
         echo "Auto merging PR using method $merge_method"
         gh pr merge --delete-branch "--$merge_method" --auto ${{ github.event.pull_request.html_url }}
+      env:
+        # Note: The GH_TOKEN env var is required for now, even though it contradicts GH's documentation. If not present we
+        # were seeing an error message like this one: https://github.com/github/docs/issues/21930#issuecomment-1310122605
+        GH_TOKEN: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -88,5 +88,3 @@ runs:
         merge_method="$(echo ${{ steps.merge-type.outputs.result }} | tr -d '"')"
         echo "Auto merging PR using method $merge_method"
         gh pr merge --delete-branch "--$merge_method" --auto ${{ github.event.pull_request.html_url }}
-      env:
-        GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_MERGE_TOKEN }}


### PR DESCRIPTION
## Purpose

* This action is not working in repository's that use the Github [Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) feature. Example failure: https://github.com/contentful/marketplace-partner-apps/actions/runs/7176568700/job/19541648881?pr=572
* The error message is "GraphQL: Changes must be made through the merge queue (mergePullRequest)". According to this [Github Issue](https://github.com/cli/cli/issues/8352) the error stems from a platform issue that occurs when using the GIthub CLI with a personal access token

## Approach

* Remove the override of the `GITHUB_TOKEN` value for this merge job. Github already provides a `GITHUB_TOKEN` to the environment (see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), which can be managed via worker permissions instead of on the token itself.