### PR TITLE
fix: correct permission name in documentations and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      pull-request: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:

--- a/example.yml
+++ b/example.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      pull-request: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:


### PR DESCRIPTION
## Purpose

We made a small typo in the recent update adding the pull request permission. We put `pull-request: write` in our example and README but it should be `pull-requests: write`.

See the table in the documentation here https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview

## Approach

* Update the docs