### PR TITLE
fix: PDHD-7367 use Vault token to enable merge

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,4 @@ runs:
         echo "Auto merging PR using method $merge_method"
         gh pr merge --delete-branch "--$merge_method" --auto ${{ github.event.pull_request.html_url }}
       env:
-        # Note: The GH_TOKEN env var is required for now, even though it contradicts GH's documentation. If not present we
-        # were seeing an error message like this one: https://github.com/github/docs/issues/21930#issuecomment-1310122605
         GH_TOKEN: ${{ steps.vault.outputs.GITHUB_MERGE_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -98,4 +98,4 @@ runs:
       env:
         # Note: The GH_TOKEN env var is required for now, even though it contradicts GH's documentation. If not present we
         # were seeing an error message like this one: https://github.com/github/docs/issues/21930#issuecomment-1310122605
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.vault.outputs.GITHUB_MERGE_TOKEN }}


### PR DESCRIPTION
The author is otherwise `github-actions` which refuses to trigger other Actions.